### PR TITLE
return centroid of clusters and adding device for different GPU training

### DIFF
--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -230,7 +230,7 @@ class KMeans:
     # END SCATTER
     if self.verbose >= 1:
       print(f'used {i+1} iterations ({round(time()-start_time, 4)}s) to cluster {batch_size} items into {self.n_clusters} clusters')
-    return closest
+    return closest, self.centroids
 
   def predict(self, X):
     """


### PR DESCRIPTION
Sometimes in model compression, there is a need of centroids.
You could make it optional, please.
Also add device in init function, used for different GPU training