### PR TITLE
Mode comparison warning in python (minor change)

### DIFF
--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -219,9 +219,9 @@ class KMeans:
 
     # SCATTER
     if self._show:
-      if self.mode is "cosine":
+      if self.mode == "cosine":
         sim = self.cos_sim(x, self.centroids)
-      elif self.mode is "euclidean":
+      elif self.mode == "euclidean":
         sim = self.euc_sim(x, self.centroids)
       closest = sim.argmax(dim=-1)
       plt.scatter(X[:, 0].cpu(), X[:, 1].cpu(), c=closest.cpu(), marker='.', cmap='hsv')

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -204,9 +204,9 @@ class MultiKMeans:
 
     # SCATTER
     if self._show:
-      if self.mode is "cosine":
+      if self.mode == "cosine":
         sim = self.cos_sim(x, self.centroids)
-      elif self.mode is "euclidean":
+      elif self.mode == "euclidean":
         sim = self.euc_sim(x, self.centroids)
       closest = sim.argmax(dim=-1)
       plt.scatter(X[:, 0].cpu(), X[:, 1].cpu(), c=closest.cpu(), marker='.', cmap='hsv')


### PR DESCRIPTION
When you run the library after first install, it throws a `SyntaxWarning`
```txt
[/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/kmeans.py:224](https://vscode-remote+ssh-002dremote-002bgnode.vscode-resource.vscode-cdn.net/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/kmeans.py:224): SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.mode is "cosine":
[/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/kmeans.py:226](https://vscode-remote+ssh-002dremote-002bgnode.vscode-resource.vscode-cdn.net/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/kmeans.py:226): SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif self.mode is "euclidean":
[/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/multi_kmeans.py:209](https://vscode-remote+ssh-002dremote-002bgnode.vscode-resource.vscode-cdn.net/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/multi_kmeans.py:209): SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.mode is "cosine":
[/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/multi_kmeans.py:211](https://vscode-remote+ssh-002dremote-002bgnode.vscode-resource.vscode-cdn.net/home2/avneesh.mishra/anaconda3/envs/vl-vpr/lib/python3.8/site-packages/fast_pytorch_kmeans/multi_kmeans.py:211): SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif self.mode is "euclidean":
```

This is a minor change in string comparison (using `==` instead of `is`).