### PR TITLE
Using torch normalize for cosine similarity normalization

### DIFF
--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -1,5 +1,6 @@
 import math
 import torch
+from torch.nn.functional import normalize
 from time import time
 import numpy as np
 from init_methods import init_methods
@@ -64,11 +65,7 @@ class KMeans:
 
       b: torch.Tensor, shape: [n, n_features]
     """
-    a_norm = a.norm(dim=-1, keepdim=True)
-    b_norm = b.norm(dim=-1, keepdim=True)
-    a = a / (a_norm + 1e-8)
-    b = b / (b_norm + 1e-8)
-    return a @ b.transpose(-2, -1)
+    return normalize(a, dim=-1) @ normalize(b, dim=-1).transpose(-2, -1)
 
   @staticmethod
   def euc_sim(a, b):

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -1,5 +1,6 @@
 import math
 import torch
+from torch.nn.functional import normalize
 from time import time
 import numpy as np
 from .init_methods import init_methods
@@ -56,11 +57,7 @@ class MultiKMeans:
       a: torch.Tensor, shape: [m, n_features]
       b: torch.Tensor, shape: [n, n_features]
     """
-    a_norm = a.norm(dim=-1, keepdim=True)
-    b_norm = b.norm(dim=-1, keepdim=True)
-    a = a / (a_norm + 1e-8)
-    b = b / (b_norm + 1e-8)
-    return a @ b.transpose(-2, -1)
+    return normalize(a, dim=-1) @ normalize(b, dim=-1).transpose(-2, -1)
 
   @staticmethod
   def euc_sim(a, b):


### PR DESCRIPTION
This version is more clear and torch.nn.functional.normalize is faster in micro-benchmarks than the current handwritten implementation.