### PR TITLE
Improving performance of k-means clustering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 dist
 *.egg-info
-fast_pytorch_kmeans\__pycache__
+fast_pytorch_kmeans/__pycache__
 upload_package.bat
+.idea

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -83,13 +83,10 @@ class KMeans:
     """
     return 2 * a @ b.transpose(-2, -1) - (a**2).sum(dim=1)[..., :, None] - (b**2).sum(dim=1)[..., None, :]
 
-  def remaining_memory(self, device=None):
+  def remaining_memory(self, device):
     """
       Get remaining memory in gpu
     """
-    if device is None:
-      device = torch.device("cuda:0")
-
     torch.cuda.synchronize(device)
     torch.cuda.empty_cache()
     if self._pynvml_exist:

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -129,8 +129,6 @@ class KMeans:
       subbatch_size = math.ceil(batch_size / ratio)
       msv, msi = [], []
       for i in range(ratio):
-        if i*subbatch_size >= batch_size:
-          continue
         sub_x = a[i*subbatch_size: (i+1)*subbatch_size]
         sub_sim = self.sim_func(sub_x, b)
         sub_max_sim_v, sub_max_sim_i = sub_sim.max(dim=-1)

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -43,8 +43,6 @@ class KMeans:
     self.verbose = verbose
     self.init_method = init_method
     self.minibatch = minibatch
-    self._loop = False
-    self._show = False
 
     if mode == 'cosine':
       self.sim_func = self.cos_sim
@@ -183,7 +181,6 @@ class KMeans:
       closest = self.max_sim(a=x, b=self.centroids)[1]
       matched_clusters, counts = closest.unique(return_counts=True)
 
-      c_grad = torch.zeros_like(self.centroids)
       expanded_closest = closest[None].expand(self.n_clusters, -1)
       mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[:, None]).to(X.dtype)
       c_grad = mask @ x / mask.sum(-1)[..., :, None]

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -170,7 +170,9 @@ class KMeans:
       self.centroids = centroids
     if self.minibatch is not None:
       num_points_in_clusters = torch.ones(self.n_clusters, device=device, dtype=X.dtype)
+
     closest = None
+    arranged_mask = torch.arange(self.n_clusters, device=device)[:, None]
     for i in range(self.max_iter):
       iter_time = time()
       if self.minibatch is not None:
@@ -182,7 +184,7 @@ class KMeans:
         closest = self.max_sim(a=x, b=self.centroids)[1]
 
       expanded_closest = closest[None].expand(self.n_clusters, -1)
-      mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[:, None]).to(X.dtype)
+      mask = (expanded_closest==arranged_mask).to(X.dtype)
       c_grad = mask @ x / mask.sum(-1)[..., :, None]
       torch.nan_to_num_(c_grad)
 

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -170,7 +170,8 @@ class KMeans:
       self.centroids = init_methods[self.init_method](X, self.n_clusters, self.minibatch)
     else:
       self.centroids = centroids
-    num_points_in_clusters = torch.ones(self.n_clusters, device=device, dtype=X.dtype)
+    if self.minibatch is not None:
+      num_points_in_clusters = torch.ones(self.n_clusters, device=device, dtype=X.dtype)
     closest = None
     for i in range(self.max_iter):
       iter_time = time()
@@ -189,10 +190,10 @@ class KMeans:
       error = (c_grad - self.centroids).pow(2).sum()
       if self.minibatch is not None:
         lr = 1/num_points_in_clusters[:,None] * 0.9 + 0.1
-        # lr = 1/num_points_in_clusters[:,None]**0.1 
+        num_points_in_clusters[matched_clusters] += counts
       else:
         lr = 1
-      num_points_in_clusters[matched_clusters] += counts
+
       self.centroids = self.centroids * (1-lr) + c_grad * lr
       if self.verbose >= 2:
         print('iter:', i, 'error:', error.item(), 'time spent:', round(time()-iter_time, 4))

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -185,7 +185,7 @@ class KMeans:
       expanded_closest = closest[None].expand(self.n_clusters, -1)
       mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[:, None]).to(X.dtype)
       c_grad = mask @ x / mask.sum(-1)[..., :, None]
-      c_grad[c_grad!=c_grad] = 0 # remove NaNs
+      torch.nan_to_num_(c_grad)
 
       error = (c_grad - self.centroids).pow(2).sum()
       if self.minibatch is not None:

--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -175,10 +175,11 @@ class KMeans:
       iter_time = time()
       if self.minibatch is not None:
         x = X[np.random.choice(batch_size, size=[self.minibatch], replace=False)]
+        closest = self.max_sim(a=x, b=self.centroids)[1]
+        matched_clusters, counts = closest.unique(return_counts=True)
       else:
         x = X
-      closest = self.max_sim(a=x, b=self.centroids)[1]
-      matched_clusters, counts = closest.unique(return_counts=True)
+        closest = self.max_sim(a=x, b=self.centroids)[1]
 
       expanded_closest = closest[None].expand(self.n_clusters, -1)
       mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[:, None]).to(X.dtype)

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -135,7 +135,9 @@ class MultiKMeans:
       self.centroids = centroids
     if self.minibatch is not None:
       num_points_in_clusters = torch.ones(self.n_kmeans, self.n_clusters, device=device, dtype=X.dtype)
+
     closest = None
+    arranged_mask = torch.arange(self.n_clusters, device=device)[None, :, None]
     for i in range(self.max_iter):
       iter_time = time()
       if self.minibatch is not None:
@@ -147,7 +149,7 @@ class MultiKMeans:
         closest = self.max_sim(a=x, b=self.centroids)[1]
 
       expanded_closest = closest[:, None].expand(-1, self.n_clusters, -1)
-      mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[None, :, None]).to(X.dtype)
+      mask = (expanded_closest==arranged_mask).to(X.dtype)
       c_grad = mask @ x / mask.sum(-1, keepdim=True)
       torch.nan_to_num_(c_grad)
 

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -148,7 +148,7 @@ class MultiKMeans:
       expanded_closest = closest[:, None].expand(-1, self.n_clusters, -1)
       mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[None, :, None]).to(X.dtype)
       c_grad = mask @ x / mask.sum(-1, keepdim=True)
-      c_grad[c_grad!=c_grad] = 0 # remove NaNs
+      torch.nan_to_num_(c_grad)
 
       error = (c_grad - self.centroids).pow(2).sum()
       if self.minibatch is not None:

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -140,10 +140,11 @@ class MultiKMeans:
       iter_time = time()
       if self.minibatch is not None:
         x = X[:, np.random.choice(n_samples, size=[self.minibatch], replace=False)]
+        closest = self.max_sim(a=x, b=self.centroids)[1]
+        uniques = [closest[i].unique(return_counts=True) for i in range(self.n_kmeans)]
       else:
         x = X
-      closest = self.max_sim(a=x, b=self.centroids)[1]
-      uniques = [closest[i].unique(return_counts=True) for i in range(self.n_kmeans)]
+        closest = self.max_sim(a=x, b=self.centroids)[1]
 
       expanded_closest = closest[:, None].expand(-1, self.n_clusters, -1)
       mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[None, :, None]).to(X.dtype)

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -35,11 +35,17 @@ class MultiKMeans:
     self.max_iter = max_iter
     self.tol = tol
     self.verbose = verbose
-    self.mode = mode
     self.init_method = init_method
     self.minibatch = minibatch
     self._loop = False
     self._show = False
+
+    if mode == 'cosine':
+      self.sim_func = self.cos_sim
+    elif mode == 'euclidean':
+      self.sim_func = self.euc_sim
+    else:
+      raise NotImplementedError()
 
     try:
       import PYNVML
@@ -97,12 +103,8 @@ class MultiKMeans:
     """
     device = a.device
     n_samples = a.shape[-2]
-    if self.mode == 'cosine':
-      sim_func = self.cos_sim
-    elif self.mode == 'euclidean':
-      sim_func = self.euc_sim
 
-    sim = sim_func(a, b)
+    sim = self.sim_func(a, b)
     max_sim_v, max_sim_i = sim.max(dim=-1)
     return max_sim_v, max_sim_i
 

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -73,13 +73,10 @@ class MultiKMeans:
     """
     return 2 * a @ b.transpose(-2, -1) -(a**2).sum(dim=-1)[..., :, None] - (b**2).sum(dim=-1)[..., None, :]
 
-  def remaining_memory(self, device=None):
+  def remaining_memory(self, device):
     """
       Get remaining memory in gpu
     """
-    if device is None:
-      device = torch.device("cuda:0")
-
     torch.cuda.synchronize(device)
     torch.cuda.empty_cache()
     if self._pynvml_exist:

--- a/fast_pytorch_kmeans/multi_kmeans.py
+++ b/fast_pytorch_kmeans/multi_kmeans.py
@@ -37,8 +37,6 @@ class MultiKMeans:
     self.verbose = verbose
     self.init_method = init_method
     self.minibatch = minibatch
-    self._loop = False
-    self._show = False
 
     if mode == 'cosine':
       self.sim_func = self.cos_sim
@@ -101,8 +99,8 @@ class MultiKMeans:
       a: torch.Tensor, shape: [m, n_features]
       b: torch.Tensor, shape: [n, n_features]
     """
-    device = a.device
-    n_samples = a.shape[-2]
+    # device = a.device
+    # n_samples = a.shape[-2]
 
     sim = self.sim_func(a, b)
     max_sim_v, max_sim_i = sim.max(dim=-1)
@@ -145,7 +143,6 @@ class MultiKMeans:
         x = X
       closest = self.max_sim(a=x, b=self.centroids)[1]
       uniques = [closest[i].unique(return_counts=True) for i in range(self.n_kmeans)]
-      c_grad = torch.zeros_like(self.centroids)
 
       expanded_closest = closest[:, None].expand(-1, self.n_clusters, -1)
       mask = (expanded_closest==torch.arange(self.n_clusters, device=device)[None, :, None]).to(X.dtype)


### PR DESCRIPTION
No comprehensive tests to prove the speed increase were done, besides micro-benchmarking `torch.nan_to_num`.
But the changes are not radical and include the following:
* Setting the similarity function in the constructor.
* Doing operations for minibatch only in the `self.minibatch is not None` branch only.
* Using `torch.nan_to_num_` instead of `c_grad[c_grad!=c_grad]`
* Caching torch.arange call outside of the training loop.
* Removing other conditionals.