### PR TITLE
Prevent int and None comparison

### DIFF
--- a/fast_pytorch_kmeans/init_methods.py
+++ b/fast_pytorch_kmeans/init_methods.py
@@ -27,7 +27,7 @@ def _kpp(data: torch.Tensor, k: int, sample_size: int = -1):
        on Discrete Algorithms, 2007.
     .. [2] scipy/cluster/vq.py: _kpp
     """
-    if sample_size > 0:
+    if sample_size is not None and sample_size > 0:
         data = data[torch.randint(0, int(data.shape[0]),
                                   [min(100000, data.shape[0])], device=data.device)]
     dims = data.shape[1] if len(data.shape) > 1 else 1
@@ -74,7 +74,7 @@ def _krandinit(data: torch.Tensor, k: int, sample_size: int = -1):
     .. [1] scipy/cluster/vq.py: _krandinit
     """
     mu = data.mean(axis=0)
-    if sample_size > 0:
+    if sample_size is not None and sample_size > 0:
         data = data[torch.randint(0, int(data.shape[0]),
                                   [min(100000, data.shape[0])], device=data.device)]
     if data.ndim == 1:


### PR DESCRIPTION
When `minibatch` is set to `None` in the input of the `KMeans` class, that value is also passed to the init methods causing the following error:
`TypeError("'>' not supported between instances of 'NoneType' and 'int'")`

This pull request fixes this by first checking whether `sample_size` is `None`.