### PR TITLE
Fix KMeans docs init method options

### DIFF
--- a/fast_pytorch_kmeans/kmeans.py
+++ b/fast_pytorch_kmeans/kmeans.py
@@ -26,7 +26,7 @@ class KMeans:
     mode: {'euclidean', 'cosine'}, default: 'euclidean'
       Type of distance measure
       
-    init_method: {'random', 'point', '++'}
+    init_method: {'gaussian', 'random', 'kmeans++'}, default: 'random'
       Type of initialization
 
     minibatch: {None, int}, default: None


### PR DESCRIPTION
The options for initmethod in the KMeans docstring did not reflect the actual possible values of initmethod.